### PR TITLE
Fix removal method to use items list

### DIFF
--- a/collections/iterator_builtin/DinerMenuIterator.py
+++ b/collections/iterator_builtin/DinerMenuIterator.py
@@ -27,7 +27,7 @@ class DinerMenuIterator(Iterator):
     def remove(self) -> None:
         if self.position <= 0:
             raise IllegalStateException("You can't remove an item until you've done at least one next()")
-        if self.list[self.position-1] != None:
-            for i in range(self.position-1, len(self.list)-1):
-                self.list[i] = self.list[i+1]
-            self.list[len(self.list)-1] = None
+        if self.items[self.position-1] != None:
+            for i in range(self.position-1, len(self.items)-1):
+                self.items[i] = self.items[i+1]
+            self.items[len(self.items)-1] = None


### PR DESCRIPTION
## Summary
- fix typo in `DinerMenuIterator.remove` by replacing `self.list` with `self.items`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b8587d738832e915af60fa0b1dc56